### PR TITLE
Fix unclosed fds on unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ println!("REDIRECTING", );
 use std::io::{Read, Write};
 
 std::thread::spawn(move || {
-	let mut shh = shh::stdout().unwrap();
-	let mut stderr = std::io::stderr();
-	loop {
-		let mut buf = Vec::new();
-		shh.read_to_end(&mut buf).unwrap();
-		stderr.write_all(&buf).unwrap();
-	}
+    let mut shh = shh::stdout().unwrap();
+    let mut stderr = std::io::stderr();
+    loop {
+        let mut buf = Vec::new();
+        shh.read_to_end(&mut buf).unwrap();
+        stderr.write_all(&buf).unwrap();
+    }
 });
 
 println!("This should be printed on stderr");
@@ -53,16 +53,16 @@ The struct `Shh` implements the `Drop` trait. Upon going out of scope, the redir
 ## Example - Silencing Dropped Early
 ```rust
 println!("you will see this");
-shh::stdout().unwrap();		// Shh struct is created, and dropped, here
+shh::stdout().unwrap();        // Shh struct is created, and dropped, here
 println!("and expect not to see this, but you will");
 ```
 
 To fix this, just assign a local variable
 ```rust
 println!("you will see this");
-let shh = shh::stdout().unwrap();		// Shh struct is created here
+let shh = shh::stdout().unwrap();        // Shh struct is created here
 println!("and expect not to see this");
-drop(shh);	// and dropped here
+drop(shh);    // and dropped here
 println!("now it works!");
 ```
 

--- a/examples/empty-reads.rs
+++ b/examples/empty-reads.rs
@@ -2,17 +2,17 @@ extern crate shh;
 use std::io::Read;
 
 fn main() {
-	// if this blocks then it is failing.
-	println!("this will be printed");
-	let mut shh = shh::stdout().unwrap();
-	let mut s = String::new();
-	assert_eq!(shh.read_to_string(&mut s).unwrap(), 0); // should exit immediately and return empty string
-	assert_eq!(&s, "");
+    // if this blocks then it is failing.
+    println!("this will be printed");
+    let mut shh = shh::stdout().unwrap();
+    let mut s = String::new();
+    assert_eq!(shh.read_to_string(&mut s).unwrap(), 0); // should exit immediately and return empty string
+    assert_eq!(&s, "");
 
-	// if this blocks then it is failing.
-	eprintln!("this will be printed");
-	let mut shh = shh::stderr().unwrap();
-	let mut s = String::new();
-	assert_eq!(shh.read_to_string(&mut s).unwrap(), 0); // should exit immediately and return empty string
-	assert_eq!(&s, "");
+    // if this blocks then it is failing.
+    eprintln!("this will be printed");
+    let mut shh = shh::stderr().unwrap();
+    let mut s = String::new();
+    assert_eq!(shh.read_to_string(&mut s).unwrap(), 0); // should exit immediately and return empty string
+    assert_eq!(&s, "");
 }

--- a/examples/redirect.rs
+++ b/examples/redirect.rs
@@ -2,9 +2,9 @@ extern crate shh;
 use std::io::Read;
 
 fn main() {
-	let mut shh = shh::stdout().unwrap();
-	println!("hello, world!",);
-	let mut s = String::new();
-	shh.read_to_string(&mut s).unwrap();
-	assert_eq!(&s, "hello, world!\n");	// notice the new line!
+    let mut shh = shh::stdout().unwrap();
+    println!("hello, world!",);
+    let mut s = String::new();
+    shh.read_to_string(&mut s).unwrap();
+    assert_eq!(&s, "hello, world!\n"); // notice the new line!
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ where
 
 impl<I: Divert<D>, D> Drop for Shh<I, D> {
     fn drop(&mut self) {
-        <I as Divert<D>>::reinstate_std_stream(self.original).unwrap_or(())
+        <I as Divert<D>>::reinstate_std_stream(self.original).unwrap_or(());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,13 +29,13 @@
 //! use std::io::{Read, Write};
 //!
 //! std::thread::spawn(move || {
-//! 	let mut shh = shh::stdout().unwrap();
-//! 	let mut stderr = std::io::stderr();
-//! 	loop {
-//! 		let mut buf = Vec::new();
-//! 		shh.read_to_end(&mut buf).unwrap();
-//! 		stderr.write_all(&buf).unwrap();
-//! 	}
+//!     let mut shh = shh::stdout().unwrap();
+//!     let mut stderr = std::io::stderr();
+//!     loop {
+//!         let mut buf = Vec::new();
+//!         shh.read_to_end(&mut buf).unwrap();
+//!         stderr.write_all(&buf).unwrap();
+//!     }
 //! });
 //!
 //! println!("This should be printed on stderr");
@@ -53,16 +53,16 @@
 //! ## Example - Silencing Dropped Early
 //! ```rust
 //! println!("you will see this");
-//! shh::stdout().unwrap();		// Shh struct is created, and dropped, here
+//! shh::stdout().unwrap();        // Shh struct is created, and dropped, here
 //! println!("and expect not to see this, but you will");
 //! ```
 //!
 //! To fix this, just assign a local variable
 //! ```rust
 //! println!("you will see this");
-//! let shh = shh::stdout().unwrap();		// Shh struct is created here
+//! let shh = shh::stdout().unwrap();        // Shh struct is created here
 //! println!("and expect not to see this");
-//! drop(shh);	// and dropped here
+//! drop(shh);    // and dropped here
 //! println!("now it works!");
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,56 +70,56 @@
 
 /// Just string replace the standard api interface.
 macro_rules! create_impl_interface {
-	($os:tt, $fdandle:ty) => {
-		#[cfg($os)]
-		mod $os;
+    ($os:tt, $fdandle:ty) => {
+        #[cfg($os)]
+        mod $os;
 
-		/// My pet name for the unix Fd or windows Handle types.
-		#[cfg($os)]
-		type Fdandle = $fdandle;
+        /// My pet name for the unix Fd or windows Handle types.
+        #[cfg($os)]
+        type Fdandle = $fdandle;
 
-		/// Type alias for `Shh`ing the stdout.
-		#[cfg($os)]
-		pub type ShhStdout = Shh<$os::Impl, io::Stdout>;
+        /// Type alias for `Shh`ing the stdout.
+        #[cfg($os)]
+        pub type ShhStdout = Shh<$os::Impl, io::Stdout>;
 
-		/// Type alias for `Shh`ing the stderr.
-		#[cfg($os)]
-		pub type ShhStderr = Shh<$os::Impl, io::Stderr>;
+        /// Type alias for `Shh`ing the stderr.
+        #[cfg($os)]
+        pub type ShhStderr = Shh<$os::Impl, io::Stderr>;
 
-		/// Silence and redirect the stdout stream.
-		///
-		/// `Shh` implements `io::Read`, with all captured output able to be read back out.
-		///
-		/// # Example
-		/// ```rust
-		/// println!("you will see this");
-		/// let shh = shh::stdout().unwrap();
-		/// println!("but not this");
-		/// drop(shh);
-		/// println!("and this");
-		/// ```
-		#[cfg($os)]
-		pub fn stdout() -> io::Result<ShhStdout> {
-			Shh::new()
-		}
+        /// Silence and redirect the stdout stream.
+        ///
+        /// `Shh` implements `io::Read`, with all captured output able to be read back out.
+        ///
+        /// # Example
+        /// ```rust
+        /// println!("you will see this");
+        /// let shh = shh::stdout().unwrap();
+        /// println!("but not this");
+        /// drop(shh);
+        /// println!("and this");
+        /// ```
+        #[cfg($os)]
+        pub fn stdout() -> io::Result<ShhStdout> {
+            Shh::new()
+        }
 
-		/// Silence and redirect the stderr stream.
-		///
-		/// `Shh` implements `io::Read`, with all captured output able to be read back out.
-		///
-		/// # Example
-		/// ```rust
-		/// eprintln!("you will see this");
-		/// let shh = shh::stderr().unwrap();
-		/// eprintln!("but not this");
-		/// drop(shh);
-		/// eprintln!("and this");
-		/// ```
-		#[cfg($os)]
-		pub fn stderr() -> io::Result<ShhStderr> {
-			Shh::new()
-		}
-	};
+        /// Silence and redirect the stderr stream.
+        ///
+        /// `Shh` implements `io::Read`, with all captured output able to be read back out.
+        ///
+        /// # Example
+        /// ```rust
+        /// eprintln!("you will see this");
+        /// let shh = shh::stderr().unwrap();
+        /// eprintln!("but not this");
+        /// drop(shh);
+        /// eprintln!("and this");
+        /// ```
+        #[cfg($os)]
+        pub fn stderr() -> io::Result<ShhStderr> {
+            Shh::new()
+        }
+    };
 }
 
 create_impl_interface!(windows, std::os::windows::io::RawHandle);
@@ -131,23 +131,23 @@ use std::marker::PhantomData;
 
 /// Trait which can create a read and write pipe as files.
 pub trait Create {
-	/// Create the read and write handles, taking ownership with `File`.
-	/// Return in (read_file, write_file)
-	fn create_files() -> io::Result<(File, File)>;
+    /// Create the read and write handles, taking ownership with `File`.
+    /// Return in (read_file, write_file)
+    fn create_files() -> io::Result<(File, File)>;
 }
 
 /// Trait which defines functions that divert and reinstate streams for std devices.
 pub trait Divert<D> {
-	/// Divert from the device into the `write_file`'s handle/fd;
-	fn divert_std_stream(write_file: &File) -> io::Result<()>;
-	/// Reinstate the std device to output. Gives the original handle/fd for use.
-	fn reinstate_std_stream(original_fdandle: Fdandle) -> io::Result<()>;
+    /// Divert from the device into the `write_file`'s handle/fd;
+    fn divert_std_stream(write_file: &File) -> io::Result<()>;
+    /// Reinstate the std device to output. Gives the original handle/fd for use.
+    fn reinstate_std_stream(original_fdandle: Fdandle) -> io::Result<()>;
 }
 
 /// Trait to enable getting the handle/fd a std device was looking at.
 pub trait Device {
-	/// Obtain the original handle/fd the std device was using.
-	fn obtain_original() -> io::Result<Fdandle>;
+    /// Obtain the original handle/fd the std device was using.
+    fn obtain_original() -> io::Result<Fdandle>;
 }
 
 /// Trait to read from file.
@@ -156,8 +156,8 @@ pub trait Device {
 /// without completely blocking the thread. This trait effectively gives implementor a little more control
 /// over the reading if they want to inject their own method. Otherwise just call `.read()` on the `File`.
 pub trait ShhRead {
-	/// Read contents of file into `buf`. Works the same way as [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html)
-	fn shh_read(read_file: &File, buf: &mut [u8]) -> io::Result<usize>;
+    /// Read contents of file into `buf`. Works the same way as [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html)
+    fn shh_read(read_file: &File, buf: &mut [u8]) -> io::Result<usize>;
 }
 
 /// A structure holding the redirection data.
@@ -165,52 +165,52 @@ pub trait ShhRead {
 /// `Shh` implements `io::Read`, with all captured output able to be read back out.
 pub struct Shh<Impl, Device>
 where
-	Impl: Divert<Device>,
+    Impl: Divert<Device>,
 {
-	original: Fdandle,
-	write_file: File,
-	read_file: File,
-	impl_mrker: PhantomData<Impl>,
-	device_mrker: PhantomData<Device>,
+    original: Fdandle,
+    write_file: File,
+    read_file: File,
+    impl_mrker: PhantomData<Impl>,
+    device_mrker: PhantomData<Device>,
 }
 
 impl<I, D> Shh<I, D>
 where
-	I: Create + Divert<D>,
-	D: Device,
+    I: Create + Divert<D>,
+    D: Device,
 {
-	fn new() -> io::Result<Self> {
-		// obtain current ptr to device
-		let original = <D as Device>::obtain_original()?;
+    fn new() -> io::Result<Self> {
+        // obtain current ptr to device
+        let original = <D as Device>::obtain_original()?;
 
-		// create data (a pipe or file) that can give a Fdandle to redirect to, and be closed
-		let (read_file, write_file) = <I as Create>::create_files()?;
+        // create data (a pipe or file) that can give a Fdandle to redirect to, and be closed
+        let (read_file, write_file) = <I as Create>::create_files()?;
 
-		let shh = Shh {
-			original,
-			read_file,
-			write_file,
-			impl_mrker: PhantomData,
-			device_mrker: PhantomData,
-		};
+        let shh = Shh {
+            original,
+            read_file,
+            write_file,
+            impl_mrker: PhantomData,
+            device_mrker: PhantomData,
+        };
 
-		// redirect the device to the write fdandle
-		<I as Divert<D>>::divert_std_stream(&shh.write_file)?;
+        // redirect the device to the write fdandle
+        <I as Divert<D>>::divert_std_stream(&shh.write_file)?;
 
-		Ok(shh)
-	}
+        Ok(shh)
+    }
 }
 
 impl<I: Divert<D>, D> Drop for Shh<I, D> {
-	fn drop(&mut self) {
-		<I as Divert<D>>::reinstate_std_stream(self.original).unwrap_or(())
-	}
+    fn drop(&mut self) {
+        <I as Divert<D>>::reinstate_std_stream(self.original).unwrap_or(())
+    }
 }
 
 impl<I: Divert<D> + ShhRead, D> Read for Shh<I, D> {
-	fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-		<I as ShhRead>::shh_read(&self.read_file, buf)
-	}
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        <I as ShhRead>::shh_read(&self.read_file, buf)
+    }
 }
 
 /// Unsafe because of the `original: Fdandle`. This is retrieved from os and does not need

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -15,8 +15,8 @@ impl Create for Impl {
             return Err(io::Error::last_os_error())
         }
 
-		let read_fd = outputs[0];
-		let write_fd = outputs[1];
+        let read_fd = outputs[0];
+        let write_fd = outputs[1];
 
         let read_file = unsafe { FromRawFd::from_raw_fd(read_fd) };
         let write_file = unsafe { FromRawFd::from_raw_fd(write_fd) };
@@ -60,19 +60,19 @@ impl Device for io::Stderr {
 }
 
 impl ShhRead for Impl {
-	fn shh_read(mut read_file: &File, buf: &mut [u8]) -> io::Result<usize> {
-		let mut avail = 0;
+    fn shh_read(mut read_file: &File, buf: &mut [u8]) -> io::Result<usize> {
+        let mut avail = 0;
 
-		let r = unsafe { libc::ioctl(read_file.as_raw_fd(), libc::FIONREAD, &mut avail) };
+        let r = unsafe { libc::ioctl(read_file.as_raw_fd(), libc::FIONREAD, &mut avail) };
 
-		if r == -1 {
-			 Err(io::Error::last_os_error())
-		} else if avail == 0 {
-			 Ok(0)
-		} else {
-			read_file.read(buf)
-		}
-	}
+        if r == -1 {
+             Err(io::Error::last_os_error())
+        } else if avail == 0 {
+             Ok(0)
+        } else {
+            read_file.read(buf)
+        }
+    }
 }
 
 fn close_handle(device: Fdandle) -> io::Result<()> {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -5,134 +5,134 @@ use std::os::windows::io::{AsRawHandle, FromRawHandle};
 use winapi;
 use winapi::ctypes::c_void;
 use winapi::shared::{
-	minwindef::{DWORD, LPDWORD},
-	ntdef::NULL,
+    minwindef::{DWORD, LPDWORD},
+    ntdef::NULL,
 };
 use winapi::um::{
-	handleapi::INVALID_HANDLE_VALUE,
-	minwinbase::{OVERLAPPED, SECURITY_ATTRIBUTES},
-	winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE},
-	winnt::HANDLE,
+    handleapi::INVALID_HANDLE_VALUE,
+    minwinbase::{OVERLAPPED, SECURITY_ATTRIBUTES},
+    winbase::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE},
+    winnt::HANDLE,
 };
 
 pub struct Impl;
 
 impl Create for Impl {
-	fn create_files() -> io::Result<(File, File)> {
-		let mut read_handle: HANDLE = NULL;
-		let mut write_handle: HANDLE = NULL;
+    fn create_files() -> io::Result<(File, File)> {
+        let mut read_handle: HANDLE = NULL;
+        let mut write_handle: HANDLE = NULL;
 
-		let create_pipe_result = unsafe {
-			winapi::um::namedpipeapi::CreatePipe(
-				&mut read_handle,
-				&mut write_handle,
-				NULL as *mut SECURITY_ATTRIBUTES,
-				0, // default buffer size
-			)
-		};
+        let create_pipe_result = unsafe {
+            winapi::um::namedpipeapi::CreatePipe(
+                &mut read_handle,
+                &mut write_handle,
+                NULL as *mut SECURITY_ATTRIBUTES,
+                0, // default buffer size
+            )
+        };
 
-		match create_pipe_result {
-			0 => Err(io::Error::last_os_error()),
-			_ => Ok((
-				unsafe { File::from_raw_handle(read_handle as Fdandle) },
-				unsafe { File::from_raw_handle(write_handle as Fdandle) },
-			)),
-		}
-	}
+        match create_pipe_result {
+            0 => Err(io::Error::last_os_error()),
+            _ => Ok((
+                unsafe { File::from_raw_handle(read_handle as Fdandle) },
+                unsafe { File::from_raw_handle(write_handle as Fdandle) },
+            )),
+        }
+    }
 }
 
 impl Divert<io::Stdout> for Impl {
-	fn divert_std_stream(write_file: &File) -> io::Result<()> {
-		set_std_handle(STD_OUTPUT_HANDLE, write_file.as_raw_handle())
-	}
+    fn divert_std_stream(write_file: &File) -> io::Result<()> {
+        set_std_handle(STD_OUTPUT_HANDLE, write_file.as_raw_handle())
+    }
 
-	fn reinstate_std_stream(orignal_handle: Fdandle) -> io::Result<()> {
-		set_std_handle(STD_OUTPUT_HANDLE, orignal_handle)
-	}
+    fn reinstate_std_stream(orignal_handle: Fdandle) -> io::Result<()> {
+        set_std_handle(STD_OUTPUT_HANDLE, orignal_handle)
+    }
 }
 
 impl Divert<io::Stderr> for Impl {
-	fn divert_std_stream(write_file: &File) -> io::Result<()> {
-		set_std_handle(STD_ERROR_HANDLE, write_file.as_raw_handle())
-	}
+    fn divert_std_stream(write_file: &File) -> io::Result<()> {
+        set_std_handle(STD_ERROR_HANDLE, write_file.as_raw_handle())
+    }
 
-	fn reinstate_std_stream(orignal_handle: Fdandle) -> io::Result<()> {
-		set_std_handle(STD_ERROR_HANDLE, orignal_handle)
-	}
+    fn reinstate_std_stream(orignal_handle: Fdandle) -> io::Result<()> {
+        set_std_handle(STD_ERROR_HANDLE, orignal_handle)
+    }
 }
 
 impl Device for io::Stdout {
-	fn obtain_original() -> io::Result<Fdandle> {
-		get_std_handle(STD_OUTPUT_HANDLE)
-	}
+    fn obtain_original() -> io::Result<Fdandle> {
+        get_std_handle(STD_OUTPUT_HANDLE)
+    }
 }
 
 impl Device for io::Stderr {
-	fn obtain_original() -> io::Result<Fdandle> {
-		get_std_handle(STD_ERROR_HANDLE)
-	}
+    fn obtain_original() -> io::Result<Fdandle> {
+        get_std_handle(STD_ERROR_HANDLE)
+    }
 }
 
 impl ShhRead for Impl {
-	fn shh_read(read_file: &File, buf: &mut [u8]) -> io::Result<usize> {
-		let read_handle = read_file.as_raw_handle();
+    fn shh_read(read_file: &File, buf: &mut [u8]) -> io::Result<usize> {
+        let read_handle = read_file.as_raw_handle();
 
-		if !has_bytes(read_handle)? {
-			return Ok(0);
-		}
+        if !has_bytes(read_handle)? {
+            return Ok(0);
+        }
 
-		let buf_len: DWORD = buf.len() as DWORD;
-		let mut bytes_read: DWORD = 0;
+        let buf_len: DWORD = buf.len() as DWORD;
+        let mut bytes_read: DWORD = 0;
 
-		let read_result = unsafe {
-			winapi::um::fileapi::ReadFile(
-				read_handle as HANDLE,
-				buf.as_mut_ptr() as *mut c_void,
-				buf_len,
-				&mut bytes_read,
-				NULL as *mut OVERLAPPED,
-			)
-		};
+        let read_result = unsafe {
+            winapi::um::fileapi::ReadFile(
+                read_handle as HANDLE,
+                buf.as_mut_ptr() as *mut c_void,
+                buf_len,
+                &mut bytes_read,
+                NULL as *mut OVERLAPPED,
+            )
+        };
 
-		match read_result {
-			0 => Err(io::Error::last_os_error()),
-			_ => Ok(bytes_read as usize),
-		}
-	}
+        match read_result {
+            0 => Err(io::Error::last_os_error()),
+            _ => Ok(bytes_read as usize),
+        }
+    }
 }
 
 fn get_std_handle(device: DWORD) -> io::Result<Fdandle> {
-	match unsafe { winapi::um::processenv::GetStdHandle(device) } {
-		INVALID_HANDLE_VALUE => Err(io::Error::last_os_error()),
-		handle => Ok(handle as Fdandle),
-	}
+    match unsafe { winapi::um::processenv::GetStdHandle(device) } {
+        INVALID_HANDLE_VALUE => Err(io::Error::last_os_error()),
+        handle => Ok(handle as Fdandle),
+    }
 }
 
 fn set_std_handle(device: DWORD, handle: Fdandle) -> io::Result<()> {
-	match unsafe { winapi::um::processenv::SetStdHandle(device, handle as HANDLE) } {
-		0 => Err(io::Error::last_os_error()),
-		_ => Ok(()),
-	}
+    match unsafe { winapi::um::processenv::SetStdHandle(device, handle as HANDLE) } {
+        0 => Err(io::Error::last_os_error()),
+        _ => Ok(()),
+    }
 }
 
 /// Uses PeekNamedPipe and checks TotalBytesAvail
 fn has_bytes(handle: Fdandle) -> io::Result<bool> {
-	let mut bytes_avail: DWORD = 0;
+    let mut bytes_avail: DWORD = 0;
 
-	let result = unsafe {
-		winapi::um::namedpipeapi::PeekNamedPipe(
-			handle as HANDLE,
-			NULL as *mut c_void,
-			0,
-			NULL as LPDWORD,
-			&mut bytes_avail,
-			NULL as LPDWORD,
-		)
-	};
+    let result = unsafe {
+        winapi::um::namedpipeapi::PeekNamedPipe(
+            handle as HANDLE,
+            NULL as *mut c_void,
+            0,
+            NULL as LPDWORD,
+            &mut bytes_avail,
+            NULL as LPDWORD,
+        )
+    };
 
-	if result == 0 {
-		return Err(io::Error::last_os_error());
-	}
+    if result == 0 {
+        return Err(io::Error::last_os_error());
+    }
 
-	Ok(bytes_avail > 0)
+    Ok(bytes_avail > 0)
 }


### PR DESCRIPTION
Hey!

I was getting errors due to running out of available file handles. This fixed that.

Note the first commit runs `cargo fmt`, the second is the actual patch.